### PR TITLE
[Common] Create empty list text component

### DIFF
--- a/src/components/Checklist.js
+++ b/src/components/Checklist.js
@@ -5,6 +5,7 @@ import firebase from "firebase"
 
 import AddTripItem from "./AddTripItem"
 import Flex from "./common/Flex"
+import EmptyListText from "./common/EmptyListText"
 import Icon from "@expo/vector-icons"
 import Text from "./common/Text"
 
@@ -74,25 +75,15 @@ class Checklist extends Component {
           return (
             <Flex>
               <View style={styles.container}>
-                {!!this._tripItems.length && (
-                  <Text size="xlarge" color={Colors.darkGray} style={styles.header} type={Fonts.CerealBold}>
-                    Items for your trip
-                  </Text>
-                )}
                 <FlatList
                   data={this._tripItems}
                   keyExtractor={(item, index) => index.toString()}
                   showsVerticalScrollIndicator={false}
                   renderItem={this._renderItem}
                   ListEmptyComponent={(
-                    <Text
-                      color={Colors.darkGray}
-                      size="xxxxxlarge"
-                      style={styles.emptyText}
-                      type={Fonts.CerealExtraBold}
-                    >
+                    <EmptyListText>
                       Create a list of essential items for your trip
-                    </Text>
+                    </EmptyListText>
                   )}
                 />
               </View>
@@ -110,14 +101,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingHorizontal: DEFAULT_PADDING,
-  },
-  emptyText: {
-    paddingHorizontal: DEFAULT_PADDING,
-    paddingTop: DEVICE_HEIGHT * .05,
-    textAlign: "center",
-  },
-  header: {
-    paddingTop: DEFAULT_PADDING,
   },
   headerIcon: {
     paddingHorizontal: DEFAULT_PADDING / 2,

--- a/src/components/Itinerary.js
+++ b/src/components/Itinerary.js
@@ -5,6 +5,7 @@ import firebase from "firebase"
 import moment from "moment"
 
 import Flex from "./common/Flex"
+import EmptyListText from "./common/EmptyListText"
 import Icon from "@expo/vector-icons"
 import Headline from "./common/Headline"
 import Text from "./common/Text"
@@ -154,14 +155,9 @@ class Itinerary extends Component {
                     renderItem={this._renderEvent}
                     showsVerticalScrollIndicator={false}
                     ListEmptyComponent={(
-                      <Text
-                        color={Colors.darkGray}
-                        size="xxxxxlarge"
-                        style={styles.emptyText}
-                        type={Fonts.CerealExtraBold}
-                      >
+                      <EmptyListText>
                         No events for this date
-                      </Text>
+                      </EmptyListText>
                     )}
                   />
                 </Flex>
@@ -193,11 +189,6 @@ const styles = StyleSheet.create({
     height: 10,
     marginLeft: -5,
     width: 10,
-  },
-  emptyText: {
-    paddingHorizontal: DEFAULT_PADDING,
-    paddingTop: DEVICE_HEIGHT * .05,
-    textAlign: "center",
   },
   eventItem: {
     alignItems: "center",

--- a/src/components/Polls.js
+++ b/src/components/Polls.js
@@ -4,6 +4,7 @@ import { Subscribe } from "unstated"
 
 import AddButton from "./common/AddButton"
 import Flex from "./common/Flex"
+import EmptyListText from "./common/EmptyListText"
 import Headline from "./common/Headline"
 import PollItem from "./PollItem"
 import Text from "./common/Text"
@@ -44,14 +45,9 @@ class Polls extends Component {
                 renderItem={this._renderItem}
                 showsVerticalScrollIndicator={false}
                 ListEmptyComponent={(
-                  <Text
-                    color={Colors.darkGray}
-                    size="xxxxxlarge"
-                    style={styles.emptyText}
-                    type={Fonts.CerealExtraBold}
-                  >
+                  <EmptyListText>
                     Create polls for your trip
-                  </Text>
+                  </EmptyListText>
                 )}
               />
             </Flex>
@@ -65,11 +61,6 @@ class Polls extends Component {
 export default Polls
 
 const styles = StyleSheet.create({
-  emptyText: {
-    paddingHorizontal: DEFAULT_PADDING,
-    paddingTop: DEVICE_HEIGHT * .05,
-    textAlign: "center",
-  },
   line: {
     borderColor: Colors.lightGray,
     borderLeftWidth: StyleSheet.hairlineWidth,

--- a/src/components/common/EmptyListText.js
+++ b/src/components/common/EmptyListText.js
@@ -1,0 +1,36 @@
+import React from "react"
+import { StyleSheet } from "react-native"
+
+import Text from "./Text"
+
+import { DEVICE_HEIGHT } from "../../constants/dimensions"
+import { Colors, DEFAULT_PADDING, Fonts } from "../../constants/style"
+
+const EmptyListText = ({
+  children,
+  color = Colors.darkGray,
+  font = Fonts.CerealExtraBold,
+  size = "xxxxxlarge",
+  style,
+}) => {
+  return (
+    <Text
+      color={color}
+      size={size}
+      style={[styles.text, style]}
+      type={font}
+    >
+      {children}
+    </Text>
+  )
+}
+
+export default EmptyListText
+
+const styles = StyleSheet.create({
+  text: {
+    paddingHorizontal: DEFAULT_PADDING,
+    paddingTop: DEVICE_HEIGHT * .05,
+    textAlign: "center",
+  },
+})


### PR DESCRIPTION
Creates empty list text component used in `Checklist`, `Itinerary` , and `Polls`. Will be used in `Suggestions` as well.